### PR TITLE
Use after parameter inside of appendingEllipsis

### DIFF
--- a/Sources/TimelaneCore/TimelaneCore.swift
+++ b/Sources/TimelaneCore/TimelaneCore.swift
@@ -112,7 +112,7 @@ public class Timelane {
 
 fileprivate extension String {
     func appendingEllipsis(after: Int) -> String {
-        guard count > 50 else { return self }
-        return prefix(50).appending("...")
+        guard count > after else { return self }
+        return prefix(after).appending("...")
     }
 }


### PR DESCRIPTION
The `after` parameter wasn't being used inside of the body of `appendingEllipsis` method. This PR uses the parameter instead of the hardcoded `50`. This PR doesn't affect behavior since both usages of `appendingEllipsis` were passing in `50` already.