### PR TITLE
Support for older system versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "TimelaneCore",
     platforms: [
-      .macOS(.v10_14),
-      .iOS(.v12),
-      .tvOS(.v12),
-      .watchOS(.v5)
+      .macOS(.v10_10),
+      .iOS(.v8),
+      .tvOS(.v9),
+      .watchOS(.v2)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/TimelaneCore/TimelaneCore.swift
+++ b/Sources/TimelaneCore/TimelaneCore.swift
@@ -6,11 +6,12 @@
 import Foundation
 import os
 
+@available(macOS 10.14, iOS 12, tvOS 12, watchOS 5, *)
 public class Timelane {
     
     static let version = 1
     static var log: OSLog = {
-        if #available(macOS 10.15, iOS 13, *) {
+        if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
             return OSLog(subsystem: "tools.timelane.subscriptions", category: OSLog.Category.dynamicStackTracing)
         } else {
             // Fallback on a hardcoded category name.


### PR DESCRIPTION
I would like to integrate Timelane into some of my projects, but the version requirements don't allow it. This PR makes the package compilable against the projects that support older system versions, but annotates the `Timelane` as available only on systems supporting `os_signpost`.

The PR also fixes tvOS and watchOS build error caused by missing `@available` parameters.