### PR TITLE
Introduces LaneType in Core

### DIFF
--- a/Sources/TimelaneCore/TimelaneCore.swift
+++ b/Sources/TimelaneCore/TimelaneCore.swift
@@ -19,7 +19,7 @@ public class Timelane {
         }
     }()
 
-    enum LaneType: Int, CaseIterable {
+    public enum LaneType: Int, CaseIterable {
         case subscription, event
     }
 

--- a/Sources/TimelaneCore/TimelaneCore.swift
+++ b/Sources/TimelaneCore/TimelaneCore.swift
@@ -18,6 +18,11 @@ public class Timelane {
             return OSLog(subsystem: "tools.timelane.subscriptions", category: "DynamicStackTracing")
         }
     }()
+
+    enum LaneType: Int, CaseIterable {
+        case subscription, event
+    }
+
     public class Subscription {
         
         private static var subscriptionCounter: UInt64 = 0


### PR DESCRIPTION
Since RxTimelane and TimelaneCombine both define a LaneType that is in now way platform-specific, it's more convenient to make it part of TimelaneCore and have RxTimelane and TimelaneCombine use the Core's LaneType