### PR TITLE
Supporting all platforms with Carthage

### DIFF
--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -310,12 +310,12 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				ONLY_ACTIVE_ARCH = YES;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "macosx iphoneos watchos appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -315,7 +315,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -312,7 +312,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 		BC7AD52F2417C4D20022D198 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ADDITIONAL_SDKS = "watchos appletvos macosx";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -292,6 +293,7 @@
 		BC7AD5302417C4D20022D198 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ADDITIONAL_SDKS = "watchos appletvos macosx";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				ONLY_ACTIVE_ARCH = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -310,6 +310,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchossimulator watchos appletvossimulator appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -314,7 +314,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchossimulator watchos appletvossimulator appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -315,7 +315,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -312,7 +312,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -315,7 +315,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos appletvsimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -308,6 +309,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -315,7 +315,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 		BC7AD52F2417C4D20022D198 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADDITIONAL_SDKS = "watchos appletvos macosx";
+				ADDITIONAL_SDKS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -293,7 +293,7 @@
 		BC7AD5302417C4D20022D198 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ADDITIONAL_SDKS = "watchos appletvos macosx";
+				ADDITIONAL_SDKS = "";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -282,7 +282,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -309,7 +309,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos macosx";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macosx";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -284,7 +284,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -312,7 +312,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos appletvos macos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
+++ b/TimelaneCore/TimelaneCore.xcodeproj/project.pbxproj
@@ -283,8 +283,9 @@
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchossimulator watchos appletvossimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -311,8 +312,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.icanzilb.TimelaneCore;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos appletvos";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchossimulator watchos appletvossimulator appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
This PR adds all supported platforms to the framework project build settings.

Apparently there were two key moments:

 - use macOS as the base SDK (hello, carthage?)
 - and not building in release for the watch and tv simulators (failing?)