### PR TITLE
Add LaneTypeOptions to use as a filter parameter

### DIFF
--- a/Sources/TimelaneCore/TimelaneCore.swift
+++ b/Sources/TimelaneCore/TimelaneCore.swift
@@ -22,6 +22,16 @@ public class Timelane {
     public enum LaneType: Int, CaseIterable {
         case subscription, event
     }
+    
+    public struct LaneTypeOptions: OptionSet {
+        public let rawValue: Int
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+        public static let subscription: LaneTypeOptions = .init(rawValue: 1 << 0)
+        public static let event: LaneTypeOptions        = .init(rawValue: 1 << 1)
+        public static let all: LaneTypeOptions          = [.subscription, .event]
+    }
 
     public typealias Logger = (_ type: OSSignpostType, _ dso: UnsafeRawPointer, _ log: OSLog, _ name: StaticString, _ signpostID: OSSignpostID, _ format: StaticString, _ arguments: CVarArg...) -> Void
     public static let defaultLogger: Logger = os_signpost


### PR DESCRIPTION
This PR adds an implementation for an `OptionSet` for the `LaneType` which can be used as a filter parameter like:

```swift
func lane(/* ... */
          filter: Timelane.LaneTypeOptions = .all,
          /* ... */)
```

Closes #21 