### PR TITLE
Remove unsafeFlags

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,7 @@ let package = Package(
     targets: [
         .target(
             name: "TimelaneCore",
-            dependencies: [],
-            linkerSettings: [
-                .unsafeFlags(["-Xlinker", "-application_extension"])
-            ]),
+            dependencies: []),
         .target(
             name: "TimelaneCoreTestUtils",
             dependencies: [],


### PR DESCRIPTION
Unsafe flags break numbered releases.

Closes #32 again:
The issue I had was that I've added TimelaneCombine to both the app
target as well as the extension target. This led to TimelaneCombine
being built for the whole app instead of just with the extension api.
When including TimelaneCombine only into the extension everything works
flawlessly.
Both the app and the extension can be profiled.